### PR TITLE
add ftw.theming support: declare fa icons.

### DIFF
--- a/ftw/contacts/configure.zcml
+++ b/ftw/contacts/configure.zcml
@@ -12,6 +12,7 @@
     <include file="permissions.zcml" />
     <include package=".browser" />
     <include file="lawgiver.zcml" zcml:condition="installed ftw.lawgiver" />
+    <include file="resources.zcml" zcml:condition="installed ftw.theming" />
 
     <i18n:registerTranslations directory="locales" />
 

--- a/ftw/contacts/resources.zcml
+++ b/ftw/contacts/resources.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:theme="http://namespaces.zope.org/ftw.theming"
+    i18n_domain="ftw.news">
+
+    <include package="ftw.theming" file="meta.zcml"/>
+
+    <theme:resources profile="ftw.contacts:default" slot="addon">
+        <theme:scss file="resources/contacts.scss" />
+    </theme:resources>
+
+</configure>

--- a/ftw/contacts/resources/contacts.scss
+++ b/ftw/contacts/resources/contacts.scss
@@ -1,0 +1,3 @@
+@include portal-type-font-awesome-icon(ftw-contacts-contactfolder, users);
+@include portal-type-font-awesome-icon(ftw-contacts-contact, user);
+@include portal-type-font-awesome-icon(ftw-contacts-memberblock, user);


### PR DESCRIPTION
Declare font-awesome type icons when ftw.theming is installed.

<img width="737" alt="bildschirmfoto 2015-08-25 um 09 33 38" src="https://cloud.githubusercontent.com/assets/7469/9461157/62023c9e-4b0c-11e5-91af-66e12ec5fd66.png">
