### PR TITLE
Remove image caption.

### DIFF
--- a/ftw/contacts/simplelayout/memberblock.pt
+++ b/ftw/contacts/simplelayout/memberblock.pt
@@ -13,9 +13,6 @@
       <img tal:replace="structure contact/@@images/image/mini" />
     </div>
     <div tal:condition="not:contact/image" tal:attributes="class string:memberBlockPortraitEmpty sl-image right gender-${contact/gender}"></div>
-    <p class="imageCaption" tal:define="description view/image_caption"
-    tal:condition="description"
-    tal:content="description" />
   </tal:image>
   <div class="memberContactInfo">
     <strong>

--- a/ftw/contacts/tests/test_member_block_view.py
+++ b/ftw/contacts/tests/test_member_block_view.py
@@ -37,24 +37,6 @@ class TestMemberBlockView(TestCase):
         self.assertEqual(u'A MemberBlock', browser.css('h3').first.text)
 
     @browsing
-    def test_image_caption_is_contact_title_if_has_permission(self, browser):
-        contact = create(Builder('contact')
-                         .with_minimal_info(u'Ch\xf6ck', u'4orris')
-                         .within(self.contactfolder))
-
-        member_block = create(Builder('member block')
-                              .within(self.contactfolder)
-                              .contact(contact)
-                              .titled(u"A MemberBlock")
-                              .having(show_image=True))
-
-        browser.login().visit(member_block, view="block_view")
-
-        self.assertEqual(
-            u'Ch\xf6ck 4orris',
-            browser.css('.imageCaption').first.text)
-
-    @browsing
     def test_call_with_deleted_contact_returns_hint(self, browser):
 
         contact = create(Builder('contact')


### PR DESCRIPTION
It has been decided that the caption is not needed anymore because the name of the contact is already displayed next to the image.