### PR TITLE
Replace special chars in search-query with empty string

### DIFF
--- a/ftw/contacts/browser/contactfolder.py
+++ b/ftw/contacts/browser/contactfolder.py
@@ -110,20 +110,24 @@ class ContactFolderReload(BrowserView):
             SearchableText='')
 
         basequery.update(query)
-        self._cleanup_query(basequery)
-        return basequery
+        return self._cleanup_query(basequery)
 
     def _cleanup_query(self, query):
         text = query.get('SearchableText')
 
         # Remove unsupported words
         text = re.sub(re.compile(
-            r'\W', re.UNICODE), r' ', text.decode('utf-8')).encode('utf-8')
+            r'[^\w\s]', re.UNICODE), r'', text.decode('utf-8')).encode('utf-8')
+
+        text = text.strip()
 
         if not text:
+            query.pop('SearchableText')
             return query
 
         # Add wildcard
         text = "{0}*".format(text)
 
         query.update({'SearchableText': text})
+
+        return query

--- a/ftw/contacts/tests/test_contact_folder_reload.py
+++ b/ftw/contacts/tests/test_contact_folder_reload.py
@@ -168,6 +168,52 @@ class TestContactFolderReloadView(TestCase):
         self.assertEqual(1, len(browser.css('.letter.withContent')))
 
     @browsing
+    def test_search_with_special_chars(self, browser):
+        create(Builder('contact')
+               .with_minimal_info(u'Chuck', u'4orris')
+               .within(self.contactfolder))
+
+        self.request.form['searchable_text'] = "Ch/*+uck 4or"
+
+        view = ContactFolderReload(self.contactfolder, self.request)
+        data = json.loads(view())
+
+        self.assertEqual(
+            1, data.get('max_contacts'),
+            "There should be one contact, the 'Chuck 4orris'. " +
+            "The special chars are replaced with an empty string.")
+
+    @browsing
+    def test_search_only_special_chars(self, browser):
+        create(Builder('contact')
+               .with_minimal_info(u'Chuck', u'4orris')
+               .within(self.contactfolder))
+
+        self.request.form['searchable_text'] = "  /*+  "
+
+        view = ContactFolderReload(self.contactfolder, self.request)
+        data = json.loads(view())
+
+        self.assertEqual(
+            1, data.get('max_contacts'),
+            "There should be all contacts." +
+            "The special chars are replaced with an empty string.")
+
+    @browsing
+    def test_search_with_empty_string(self, browser):
+        create(Builder('contact')
+               .with_minimal_info(u'Chuck', u'4orris')
+               .within(self.contactfolder))
+
+        self.request.form['searchable_text'] = ""
+
+        view = ContactFolderReload(self.contactfolder, self.request)
+        data = json.loads(view())
+
+        self.assertEqual(
+            1, data.get('max_contacts'), "There should be all contacts")
+
+    @browsing
     def test_max_contacts_with_letters_filter(self, browser):
         create(Builder('contact')
                .with_minimal_info(u'Chuck', u'Borris')


### PR DESCRIPTION
@jone 

We have a contactdirectory:

![bildschirmfoto 2015-09-08 um 16 13 38](https://cloud.githubusercontent.com/assets/557005/9736974/9da1b62e-5644-11e5-9771-eb8c31296a6d.png)

If we replace the special chars with a space, we'll not be able to find contacts if the user inserts a special char:

![bildschirmfoto 2015-09-08 um 16 12 47](https://cloud.githubusercontent.com/assets/557005/9736960/8ca09c6e-5644-11e5-8c58-2a9009916984.png)

I changed the _cleanup_query to replace the special chars with a empty string. Now it's possible to find them:

![bildschirmfoto 2015-09-08 um 16 11 54](https://cloud.githubusercontent.com/assets/557005/9737005/bbcf45bc-5644-11e5-9061-1ebbd3452cc6.png)
