### PR TITLE
Es 700 path source for members

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -3,11 +3,5 @@ extends =
     test-plone-4.3.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
-parts += upgrade
-
-[upgrade]
-recipe = zc.recipe.egg:scripts
-eggs = ftw.upgrade
-
 [instance]
 eggs += ftw.contacts [simplelayout, geo]

--- a/development.cfg
+++ b/development.cfg
@@ -3,5 +3,11 @@ extends =
     test-plone-4.3.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
+parts += upgrade
+
+[upgrade]
+recipe = zc.recipe.egg:scripts
+eggs = ftw.upgrade
+
 [instance]
 eggs += ftw.contacts [simplelayout, geo]

--- a/ftw/contacts/profiles/default/metadata.xml
+++ b/ftw/contacts/profiles/default/metadata.xml
@@ -5,5 +5,6 @@
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-plone.app.relationfield:default</dependency>
     <dependency>profile-plone.formwidget.contenttree:default</dependency>
+    <dependency>profile-ftw.upgrade:default</dependency>
   </dependencies>
 </metadata>

--- a/ftw/contacts/simplelayout/configure.zcml
+++ b/ftw/contacts/simplelayout/configure.zcml
@@ -3,10 +3,13 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     i18n_domain="ftw.contacts">
 
     <include file="permissions.zcml" />
     <include file="lawgiver.zcml" zcml:condition="installed ftw.lawgiver" />
+
+    <include package="ftw.upgrade" file="meta.zcml" />
 
     <genericsetup:registerProfile
         name="default"
@@ -14,6 +17,11 @@
         directory="profiles/default"
         description="Installs ftw.simplelayout and adds a special memberblock."
         provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <upgrade-step:directory
+        profile="ftw.contacts.simplelayout:default"
+        directory="upgrades"
         />
 
     <browser:page

--- a/ftw/contacts/simplelayout/contents/memberblock.py
+++ b/ftw/contacts/simplelayout/contents/memberblock.py
@@ -2,14 +2,37 @@ from collective import dexteritytextindexer
 from ftw.contacts import _
 from ftw.contacts.interfaces import IContact
 from ftw.contacts.interfaces import IMemberBlock
+from ftw.contacts.simplelayout.interfaces import IMemberRegistry
 from ftw.contacts.utils import get_organization
+from plone import api
 from plone.dexterity.content import Item
 from plone.formwidget.contenttree import ObjPathSourceBinder
+from plone.registry.interfaces import IRegistry
 from plone.supermodel import model
 from z3c.relationfield.schema import RelationChoice
 from z3c.schema.email import RFC822MailAddress
 from zope import schema
+from zope.component import getUtility
 from zope.interface import implements
+
+
+class AddressObjPathSourceBinder(ObjPathSourceBinder):
+    def __init__(self):
+        super(AddressObjPathSourceBinder, self).__init__(
+            navigation_tree_query={},
+            object_provides=IContact.__identifier__)
+
+    def __call__(self, context):
+        portal = api.portal.get()
+        portal_path = '/'.join(portal.getPhysicalPath())
+
+        registry = getUtility(IRegistry).forInterface(IMemberRegistry)
+        path = registry.member_nav_tree_query_path or ''
+
+        self.navigation_tree_query['path'] = {
+            'query': portal_path + path}
+
+        return super(AddressObjPathSourceBinder, self).__call__(context)
 
 
 class IMemberBlockSchema(model.Schema):
@@ -28,7 +51,7 @@ class IMemberBlockSchema(model.Schema):
 
     contact = RelationChoice(
         title=_(u'label_contact_reference', default=u'Contact reference'),
-        source=ObjPathSourceBinder(object_provides=IContact.__identifier__),
+        source=AddressObjPathSourceBinder(),
         required=True)
 
     dexteritytextindexer.searchable('function')

--- a/ftw/contacts/simplelayout/interfaces.py
+++ b/ftw/contacts/simplelayout/interfaces.py
@@ -1,0 +1,10 @@
+from zope.interface import Interface
+from zope import schema
+
+
+class IMemberRegistry(Interface):
+    member_nav_tree_query_path = schema.TextLine(
+        title=u"Member navigation tree query path",
+        description=u"Add the path to your contactdirectory: '/address'",
+        default=u"",
+        required=False)

--- a/ftw/contacts/simplelayout/profiles/default/metadata.xml
+++ b/ftw/contacts/simplelayout/profiles/default/metadata.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1000</version>
   <dependencies>
     <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
     <dependency>profile-ftw.contacts:default</dependency>

--- a/ftw/contacts/simplelayout/profiles/default/registry.xml
+++ b/ftw/contacts/simplelayout/profiles/default/registry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<registry>
+    <records interface="ftw.contacts.simplelayout.interfaces.IMemberRegistry" />
+</registry>

--- a/ftw/contacts/simplelayout/upgrades/20150924163411_add_member_registry_for_source_path/registry.xml
+++ b/ftw/contacts/simplelayout/upgrades/20150924163411_add_member_registry_for_source_path/registry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<registry>
+    <records interface="ftw.contacts.simplelayout.interfaces.IMemberRegistry" />
+</registry>

--- a/ftw/contacts/simplelayout/upgrades/20150924163411_add_member_registry_for_source_path/upgrade.py
+++ b/ftw/contacts/simplelayout/upgrades/20150924163411_add_member_registry_for_source_path/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddMemberRegistryForSourcePath(UpgradeStep):
+    """Add member registry for source path.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/ftw/contacts/tests/test_address_obj_path_source_binder.py
+++ b/ftw/contacts/tests/test_address_obj_path_source_binder.py
@@ -1,0 +1,35 @@
+from ftw.contacts.simplelayout.contents.memberblock import AddressObjPathSourceBinder
+from ftw.contacts.simplelayout.interfaces import IMemberRegistry
+from ftw.contacts.testing import FTW_CONTACTS_FUNCTIONAL_TESTING
+from plone.registry.interfaces import IRegistry
+from unittest2 import TestCase
+from zope.component import getUtility
+
+
+class TestAddressObjPathSourceBinder(TestCase):
+
+    layer = FTW_CONTACTS_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_nav_tree_query_is_plone_root_by_default(self):
+        AddressObjPathSourceBinder()
+        sourcebinder = AddressObjPathSourceBinder()(self.portal)
+
+        self.assertEqual(
+            {'query': '/plone'},
+            sourcebinder.navigation_tree_query.get('path')
+        )
+
+    def test_change_nav_tree_query_path_in_registry(self):
+        registry = getUtility(IRegistry).forInterface(IMemberRegistry)
+        registry.member_nav_tree_query_path = u"/address"
+
+        AddressObjPathSourceBinder()
+        sourcebinder = AddressObjPathSourceBinder()(self.portal)
+
+        self.assertEqual(
+            {'query': '/plone/address'},
+            sourcebinder.navigation_tree_query.get('path')
+        )

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(name='ftw.contacts',
           'plone.api >= 1.3.3',
           'ftw.zipexport',
           'ftw.autofeature',
+          'ftw.upgrade',
           ],
 
       tests_require=tests_require,


### PR DESCRIPTION
@maethu 

Add registry property to set the sourcepath for member-blocks.

If you add a memberblock, you can add a source-contact. 
The default path source is the plone siteroot:

![bildschirmfoto 2015-09-24 um 17 01 38](https://cloud.githubusercontent.com/assets/557005/10076917/2e453d40-62de-11e5-83da-9e19f73734ba.png)

You can set the path to a certain plone object, i.e. our contactdirectory:

![bildschirmfoto 2015-09-24 um 17 02 16](https://cloud.githubusercontent.com/assets/557005/10076958/61cc8786-62de-11e5-9f70-149b02356396.png)

And now, if you try to reference a contact through a memberblock, the path source is our contac-directory:

![bildschirmfoto 2015-09-24 um 17 02 51](https://cloud.githubusercontent.com/assets/557005/10076974/7b8dc914-62de-11e5-8a01-558cef11a5c8.png)

