### PR TITLE
Add contactfolder styling to use the given space

### DIFF
--- a/ftw/contacts/locales/de/LC_MESSAGES/ftw.contacts.po
+++ b/ftw/contacts/locales/de/LC_MESSAGES/ftw.contacts.po
@@ -222,20 +222,20 @@ msgstr "Organisation"
 #: ./ftw/contacts/contents/contact.py:107
 #: ./ftw/contacts/simplelayout/contents/memberblock.py:89
 msgid "label_phone_mobile"
-msgstr "Telefon Mobil"
+msgstr "Telefon mobil"
 
 #. Default: "Office phone number"
 #: ./ftw/contacts/browser/contact.pt:43
 #: ./ftw/contacts/contents/contact.py:100
 #: ./ftw/contacts/simplelayout/contents/memberblock.py:82
 msgid "label_phone_office"
-msgstr "Telefon Geschäftlich"
+msgstr "Telefon geschäftlich"
 
 #. Default: "Private phone number"
 #: ./ftw/contacts/browser/contact.pt:83
 #: ./ftw/contacts/contents/contact.py:164
 msgid "label_phone_private"
-msgstr "Telefon Privat"
+msgstr "Telefon privat"
 
 #. Default: "Postal code"
 #: ./ftw/contacts/contents/contact.py:70
@@ -276,12 +276,12 @@ msgstr "Geschäft"
 #. Default: "Phone M"
 #: ./ftw/contacts/browser/contact_summary.pt:23
 msgid "label_short_phone_mobile"
-msgstr "Telefon Mobile:"
+msgstr "Telefon mobile:"
 
 #. Default: "Phone O"
 #: ./ftw/contacts/browser/contact_summary.pt:19
 msgid "label_short_phone_office"
-msgstr "Telefon Geschäftlich:"
+msgstr "Telefon geschäftlich:"
 
 #. Default: "Show address"
 #: ./ftw/contacts/simplelayout/contents/memberblock.py:42

--- a/ftw/contacts/resources/contacts.scss
+++ b/ftw/contacts/resources/contacts.scss
@@ -115,7 +115,6 @@ $resource-path: "#{$portal-url}/++resource++ftw.contacts.resources";
         display: block;
         border-bottom: 1px solid $contact-border-color;
         margin-top: 2em;
-        padding-left: 2em;
         padding-bottom: 1em;
     }
 
@@ -125,21 +124,20 @@ $resource-path: "#{$portal-url}/++resource++ftw.contacts.resources";
 
     .contactInfo {
         float: left;
-        width: 50%;
 
         table {
             margin-top: 1em;
             width: 100%;
         }
         th {
-            width: 150px;
             font-weight: inherit;
             text-align: left;
+            padding-right: 10px;
         }
     }
 
     .contactImage {
-        float: left;
+        float: right;
         width: 200px;
         height: 200px;
         background-size: contain;

--- a/ftw/contacts/resources/ftw.contacts.css
+++ b/ftw/contacts/resources/ftw.contacts.css
@@ -38,7 +38,6 @@
     display: block;
     border-bottom: 1px solid #ddd;
     margin-top: 2em;
-    padding-left: 2em;
     padding-bottom: 1em;
 }
 #contact-folder-view .contactSummary:last-child {
@@ -58,18 +57,18 @@
 }
 #contact-folder-view .contactInfo {
     float: left;
-    width: 50%;
 }
 #contact-folder-view .contactInfo table {
     margin-top: 1em;
     width: 100%;
 }
 #contact-folder-view .contactInfo th {
-    width: 150px;
     font-weight: inherit;
+    text-align: left;
+    padding-right: 10px;
 }
 #contact-folder-view .contactImage {
-    float: left;
+    float: right;
     width: 200px;
     height: 200px;
     background-size: contain;


### PR DESCRIPTION
@bierik 

If the font-size is bigger than in default-plone, we have some unnecessary linebreaks.

I adjust the styling to avoid this.

Before
---------
![bildschirmfoto 2015-10-22 um 08 59 33](https://cloud.githubusercontent.com/assets/557005/10658993/7be8ce94-789c-11e5-9585-7aaef00dafeb.png)

After
------
![bildschirmfoto 2015-10-22 um 09 03 30](https://cloud.githubusercontent.com/assets/557005/10658998/854cd8c2-789c-11e5-9a61-aa5a2d2d58ac.png)
