### PR TITLE
Adjust contact_summary template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- Adjust contact_summary template to display the title in the details
+  only if it is different than the organization name.
+  This happens if you fill only an organization name without a first and last
+  name.
+  [elioschmutz]
+
 - Fix css styles for plonetheme.onegovbear
   [elioschmutz]
 

--- a/ftw/contacts/browser/contact_summary.pt
+++ b/ftw/contacts/browser/contact_summary.pt
@@ -9,7 +9,7 @@
       <div tal:condition="context/function"><span tal:content="context/function" /></div>
       <div tal:condition="context/organization"><span tal:content="context/organization" /></div>
 
-      <div><span tal:content="context/title" /></div>
+      <div><span tal:content="context/title" tal:condition="python:context.title != context.organization"/></div>
       <div tal:condition="context/address"><span tal:replace="structure python:view.safe_html(context.address)" /></div>
       <div tal:condition="python: context.postal_code and context.city">
         <span tal:content="string:${context/postal_code} ${context/city}" />


### PR DESCRIPTION
Adjust contact_summary template to display the title in the details only if it is different than the organization name.

This happens if you fill only an organization name without a first and last name.

Before:
----------

![bildschirmfoto 2016-02-02 um 09 23 07](https://cloud.githubusercontent.com/assets/557005/12743517/bfeaf520-c98e-11e5-8d65-8b9758a1b9b6.png)

After:
-------

![bildschirmfoto 2016-02-02 um 09 19 29](https://cloud.githubusercontent.com/assets/557005/12743527/c65f5f22-c98e-11e5-9008-a0ed04c523ae.png)
