### PR TITLE
Change ``reload`` view name to more specific name ``reload_contacts``.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- Change ``reload`` view name to more specific name ``reload_contacts``.
+  [elioschmutz]
+
 - Adjust contact_summary template to display the title in the details
   only if it is different than the organization name.
   This happens if you fill only an organization name without a first and last

--- a/ftw/contacts/browser/configure.zcml
+++ b/ftw/contacts/browser/configure.zcml
@@ -45,7 +45,7 @@
 
     <browser:page
         for="ftw.contacts.interfaces.IContactFolder"
-        name="reload"
+        name="reload_contacts"
         class=".contactfolder.ContactFolderReload"
         permission="zope2.View"
         />

--- a/ftw/contacts/resources/contactfolder_listing.js
+++ b/ftw/contacts/resources/contactfolder_listing.js
@@ -48,7 +48,7 @@ var ContactFolderListing = (function($) {
         if (reset) {
             index = 0;
         }
-        $.getJSON('@@reload', {
+        $.getJSON('@@reload_contacts', {
                 index_from: index,
                 index_to: index + step,
                 letter: letter,

--- a/ftw/contacts/tests/test_contact_folder_reload.py
+++ b/ftw/contacts/tests/test_contact_folder_reload.py
@@ -19,7 +19,7 @@ class TestContactFolderReloadLetter(TestCase):
         self.contactfolder = create(
             Builder('contact folder').titled(u'Contact folder'))
 
-        self.view = self.contactfolder.unrestrictedTraverse('reload')
+        self.view = self.contactfolder.unrestrictedTraverse('reload_contacts')
 
     @browsing
     def test_returns_html_letters(self, browser):
@@ -50,7 +50,7 @@ class TestContactFolderReloadContact(TestCase):
         self.contactfolder = create(
             Builder('contact folder').titled(u'Contact folder'))
 
-        self.view = self.contactfolder.unrestrictedTraverse('reload')
+        self.view = self.contactfolder.unrestrictedTraverse('reload_contacts')
 
     @browsing
     def test_returns_html_contacts(self, browser):
@@ -110,7 +110,7 @@ class TestContactFolderReloadView(TestCase):
         self.contactfolder = create(
             Builder('contact folder').titled(u'Contact folder'))
 
-        self.view = self.contactfolder.unrestrictedTraverse('reload')
+        self.view = self.contactfolder.unrestrictedTraverse('reload_contacts')
 
     @browsing
     def test_json_string_on_call(self, browser):


### PR DESCRIPTION
The reload view is sometimes used by another package.
To be unique, I change it to the more specific name ``reload_contacts``.