### PR TITLE
Fix broken profilehook name

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- Fix broken profilehook name for ftw.geo integraton.
+  [elioschmutz]
+
 - Disable rendering map widget through the viewlet.
   The map will be rendered directly in the contact.pt now.
   [elioschmutz]

--- a/ftw/contacts/geo/configure.zcml
+++ b/ftw/contacts/geo/configure.zcml
@@ -13,7 +13,7 @@
         />
 
     <profilehook:hook
-        profile="ftw.contacts:geo"
+        profile="ftw.contacts.geo:default"
         handler=".hooks.geo_profile_installed"
         />
 


### PR DESCRIPTION
The profilehook name was false.

On newly installed instances with ftw.contacts.geo integration, the hook haven't been registered.