### PR TITLE
Install a newer version of "collective.geo.openlayers".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Install a newer version of "collective.geo.openlayers". This makes the
+  "ftw.openlayerhotfix" obsolete.
+  [mbaechtold]
 
 
 1.3.0 (2016-08-10)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ simplelayout = [
     ]
 geo = [
     'ftw.geo',
-    'ftw.openlayerhotfix',
+    'collective.geo.openlayers >= 3.2b1',
     'collective.geo.bundle [dexterity]',
     ]
 ldap = [


### PR DESCRIPTION
This makes the "ftw.openlayerhotfix" obsolete.