### PR TITLE
Let the membership links point to the container of the memberblock.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- The membership links on the contact detail view now point to the
+  container containing the memberblock and not to the memberblock
+  itself. [mbaechtold]
+
 - Add option to hide the map on the contact detail view. [mbaechtold]
 
 - Add option to hide the memberships on the contact detail view. [mbaechtold]

--- a/ftw/contacts/browser/contact.py
+++ b/ftw/contacts/browser/contact.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_inner, aq_parent
 from ftw.contacts.interfaces import IMemberBlock
 from ftw.contacts.utils import get_backreferences
 from ftw.contacts.utils import safe_html
@@ -46,6 +47,15 @@ class ContactView(BrowserView):
     @property
     def img_tag(self):
         return portrait_img_tag(self.context)
+
+    def get_membership_url(self, memberblock):
+        """
+        Called from the template to construct the membership links so that
+        the link points to the container of the memberblock and not the
+        memberblock (obj) itself.
+        """
+        memberblock_container = aq_parent(aq_inner(memberblock))
+        return memberblock_container.absolute_url() + '#' + memberblock.getId()
 
 
 class ContactSummary(BrowserView):

--- a/ftw/contacts/browser/templates/contact.pt
+++ b/ftw/contacts/browser/templates/contact.pt
@@ -133,7 +133,7 @@
                 <ul>
                   <tal:items tal:repeat="member memberships">
                     <li>
-                      <a href="" tal:attributes="href string:${member/absolute_url}">
+                      <a href="" tal:attributes="href python:view.get_membership_url(member)">
                         <span tal:condition="member/organization" tal:replace="member/organization"/>
                         <span tal:condition="member/function" tal:replace="string:(${member/function})"/></a>
                     </li>

--- a/ftw/contacts/testing.py
+++ b/ftw/contacts/testing.py
@@ -6,6 +6,7 @@ from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
+from plone.testing import z2
 from zope.configuration import xmlconfig
 
 
@@ -22,8 +23,10 @@ class ContactsLayer(PloneSandboxLayer):
             '</configure>',
             context=configurationContext)
 
+        z2.installProduct(app, 'ftw.simplelayout')
+
     def setUpPloneSite(self, portal):
-        applyProfile(portal, 'ftw.contacts:default')
+        applyProfile(portal, 'ftw.simplelayout.contenttypes:default')
         applyProfile(portal, 'ftw.contacts.simplelayout:default')
         applyProfile(portal, 'ftw.zipexport:default')
 

--- a/ftw/contacts/tests/builders.py
+++ b/ftw/contacts/tests/builders.py
@@ -3,6 +3,7 @@ from ftw.builder.dexterity import DexterityBuilder
 from plone.app.textfield.value import RichTextValue
 from plone.namedfile import NamedImage
 from z3c.relationfield.relation import create_relation
+from ftw.simplelayout.tests import builders
 
 
 class ContactFolderBuilder(DexterityBuilder):

--- a/ftw/contacts/tests/test_contact_type.py
+++ b/ftw/contacts/tests/test_contact_type.py
@@ -72,6 +72,31 @@ class TestDefaultView(TestCase):
         browser.fill({u'Hide memberships': True}).submit()
         self.assertEqual([], browser.css('.memberships'))
 
+    @browsing
+    def test_membership_links_point_to_container(self, browser):
+        """
+        This test makes sure that the membership links on the contact
+        point to the container of the memberblock and not the
+        memberblock itself.
+        """
+        contact = create(Builder('contact')
+                         .with_minimal_info(u'Ch\xf6ck', u'4orris')
+                         .within(self.contactfolder))
+
+        page = create(Builder('sl content page').titled(u'Team'))
+
+        create(Builder('member block')
+               .within(page)
+               .contact(contact)
+               .titled(u"A MemberBlock")
+               .having(function=u'Epic splitter'))
+
+        browser.login().visit(contact)
+        self.assertEqual(
+            'http://nohost/plone/team#a-memberblock',
+            browser.css('.memberships li a').first.attrib['href']
+        )
+
 
 class TestIdGeneration(TestCase):
 


### PR DESCRIPTION
The membership links on the contact detail view now point to the container containing the memberblock and not to the memberblock itself.