### PR TITLE
Fix permission check in utls.py (get_backreferences). It's "View" not "zope2.View"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix permission check in utls.py (get_backreferences). It's "View" not "zope2.View".
+  [mathias.leimgruber]
+
 
 
 1.4.0 (2016-09-13)

--- a/ftw/contacts/tests/test_utils_get_backreferences.py
+++ b/ftw/contacts/tests/test_utils_get_backreferences.py
@@ -15,7 +15,7 @@ class TestBackReferences(TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
-        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        setRoles(self.portal, TEST_USER_ID, ['Site Administrator'])
 
         self.contactfolder = create(
             Builder('contact folder').titled(u'Contact folder'))

--- a/ftw/contacts/tests/test_utils_get_backreferences.py
+++ b/ftw/contacts/tests/test_utils_get_backreferences.py
@@ -55,6 +55,7 @@ class TestBackReferences(TestCase):
         self.assertEqual(
             [member_block], get_backreferences(contact, IMemberBlock))
 
+        member_block.manage_permission('View', roles=[])
         logout()
 
         self.assertEqual([], get_backreferences(contact, IMemberBlock))

--- a/ftw/contacts/utils.py
+++ b/ftw/contacts/utils.py
@@ -74,7 +74,7 @@ def get_backreferences(source_object, from_interface):
 
         obj = intids.queryObject(rel.from_id)
 
-        if obj is not None and mtool.checkPermission('zope2.View', obj):
+        if obj is not None and mtool.checkPermission('View', obj):
             result.append(obj)
     return result
 


### PR DESCRIPTION
Before only the "Manager" role was able to see referenced members. 