### PR TITLE
Improve sorting of memberships of a contact.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.4.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Sort the memberships alphabetically by the title of their container (on the
+  contact detail view). Replaces 1.4.3.
+  [mbaechtold]
 
 
 1.4.3 (2017-01-26)

--- a/ftw/contacts/browser/contact.py
+++ b/ftw/contacts/browser/contact.py
@@ -22,8 +22,8 @@ class ContactView(BrowserView):
     """
     def get_memberships(self):
         memberships = get_backreferences(self.context, IMemberBlock)
-        # Sort the memberships alphabetically by their title before returning.
-        return sorted(memberships, key=lambda membership: membership.Title().lower())
+        # Sort the memberships alphabetically by the title of their container before returning.
+        return sorted(memberships, key=lambda membership: aq_parent(aq_inner(membership)).Title().lower())
 
     def safe_html(self, text):
         return safe_html(text)

--- a/ftw/contacts/tests/test_contact_type.py
+++ b/ftw/contacts/tests/test_contact_type.py
@@ -76,7 +76,8 @@ class TestDefaultView(TestCase):
     def test_memberships_sorted_alphabetically(self, browser):
         """
         This test makes sure that the back references (AKA member ships)
-        of a contact are sorted alphabetically.
+        of a contact are sorted alphabetically by the title of their
+        container.
         """
         contact = create(Builder('contact')
                          .with_minimal_info(u'John', u'Doe')
@@ -85,20 +86,17 @@ class TestDefaultView(TestCase):
         zzz = create(Builder('sl content page').titled(u'ZZZ'))
         create(Builder('member block')
                .within(zzz)
-               .contact(contact)
-               .titled(u"A member block on ZZZ"))
+               .contact(contact))
 
         aaa = create(Builder('sl content page').titled(u'AAA'))
         create(Builder('member block')
                .within(aaa)
-               .contact(contact)
-               .titled(u"A member block on AAA"))
+               .contact(contact))
 
         ttt = create(Builder('sl content page').titled(u'TTT'))
         create(Builder('member block')
                .within(ttt)
-               .contact(contact)
-               .titled(u"A member block on TTT"))
+               .contact(contact))
 
         browser.login().visit(contact)
         self.assertEqual(


### PR DESCRIPTION
The memberships must be sorted by the title of their container because the memberships are in fact member blocks inside content pages. Most member blocks do not even have a title, so we cannot sort by the title of the block itself.

This is a follow-up of https://github.com/4teamwork/ftw.contacts/pull/43