### PR TITLE
Use primary color for load more button.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.4.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use primary color for loadmore button.
+  [Kevin Bieri]
 
 
 1.4.4 (2017-02-01)

--- a/ftw/contacts/resources/scss/contacts.scss
+++ b/ftw/contacts/resources/scss/contacts.scss
@@ -63,7 +63,7 @@
 }
 
 .contactFolderLoadMoreContacts {
-  @include button($color-button-default);
+  @include button();
   text-align: center;
   margin: 0 auto;
   display: block;


### PR DESCRIPTION
Accidentally the loadmore button is using the `default` color.
Because the loadmore button is visible for anonymous users it
should be displayed in the primary color.

## Before:
![screencapture-localhost-8080-platform-politik-und-verwaltung-kontakte-1487240510601](https://cloud.githubusercontent.com/assets/1637820/23017345/2fd312ce-f43a-11e6-9b93-5740d1095d7c.png)

## After:
![screencapture-localhost-8080-platform-politik-und-verwaltung-kontakte-1487240487838](https://cloud.githubusercontent.com/assets/1637820/23017352/3345a2be-f43a-11e6-9945-726ea4da0022.png)
