### PR TITLE
Make MemberBlock addable on plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make MemberBlock addable on plone site per default [raphael-s]
 
 
 1.4.5 (2017-02-28)

--- a/ftw/contacts/profiles/default/types/Plone_Site.xml
+++ b/ftw/contacts/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.contacts.MemberBlock" />
+    </property>
+
+</object>


### PR DESCRIPTION
When `ftw.contacts` is installed the MemberBlock can now be added to plone site per default.

We don't want an upgrade step for this because we don't want to change how existing deployments handle the MemberBlock.