### PR TITLE
Make memberblock more robust

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
+- Make memberblock more robust. [mbaechtold]
+
 - Improve contact detail view. [mbaechtold]
 
 

--- a/ftw/contacts/simplelayout/member.py
+++ b/ftw/contacts/simplelayout/member.py
@@ -12,6 +12,8 @@ class MemberView(BrowserView):
         self.contact = self.get_related_contact()
 
     def memberaccessor(self):
+        if not self.contact:
+            return None
         return IMemberAccessor(self.context)
 
     @property


### PR DESCRIPTION
The block used to fail if it did not have a reference to a contact.