### PR TITLE
Add label to email field in memberblock for consistency reasons.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
+- Add label to email field in memberblock for consistency reasons. [Kevin Bieri]
+
 - Make memberblock more robust. [mbaechtold]
 
 - Improve contact detail view. [mbaechtold]

--- a/ftw/contacts/simplelayout/templates/memberblock.pt
+++ b/ftw/contacts/simplelayout/templates/memberblock.pt
@@ -51,6 +51,7 @@
             </tal:fax>
             <tal:email tal:condition="member/email">
                 <br/>
+                <span i18n:translate="label_email">E-Mail</span>:
                 <a tal:attributes="href string:mailto:${member/email}"
                    tal:content="member/email" />
             </tal:email>


### PR DESCRIPTION
See discussion in https://github.com/4teamwork/nidau.web/issues/35

<img width="1233" alt="screen shot 2017-08-04 at 11 09 34" src="https://user-images.githubusercontent.com/1637820/28962274-73cdf20a-7905-11e7-92ba-de527c15e412.png">

