### PR TITLE
Add comma to separate address and city in contact view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add comma between address and city in contact template. [raphael-s]
 
 
 1.5.2 (2017-09-29)

--- a/ftw/contacts/browser/templates/contact.pt
+++ b/ftw/contacts/browser/templates/contact.pt
@@ -74,7 +74,7 @@
               <tr tal:condition="python: context.postal_code and context.city and context.address">
                 <th i18n:translate="label_address">Address</th>
                 <td>
-                  <span tal:replace="structure python:view.safe_html(context.address)" />
+                  <span tal:replace="structure python:view.safe_html(context.address)" />,
                   <span tal:replace="context/postal_code" />
                   <span tal:replace="context/city" />
                 </td>


### PR DESCRIPTION
Adds a comma between address and city in the contact template to visually separate the two.

Before:
<img width="614" alt="screen shot 2017-10-05 at 11 41 52" src="https://user-images.githubusercontent.com/16755391/31220930-4c395c00-a9c2-11e7-98c0-aa9a25b84212.png">

After:
<img width="614" alt="screen shot 2017-10-05 at 11 41 32" src="https://user-images.githubusercontent.com/16755391/31220933-4fa49062-a9c2-11e7-8295-99ac866b67b4.png">
