### PR TITLE
Fix contact sync for umlaut id's and group objects.

### DIFF
--- a/ftw/contacts/sync/sync.py
+++ b/ftw/contacts/sync/sync.py
@@ -138,9 +138,11 @@ def main():
             # prepend the prefix to avoid id collisions
             if ldap_config.get('userid_prefix'):
                 for dn, entry in plugin_records:
+                    if not dn:
+                        continue
                     id_arr = entry.get(get_ldap_attribute_mapper().id())
                     if id_arr:
-                        id_arr[0] = ldap_config.get('userid_prefix') + id_arr[0]
+                        id_arr[0] = ldap_config.get('userid_prefix').encode('ascii') + id_arr[0]
 
             ldap_records += plugin_records
 


### PR DESCRIPTION
Follow up to: https://github.com/4teamwork/ftw.contacts/pull/62

This change was already deployed on the test system, but wasn't synced. 🙈 

The check on the dn (not always the dn, but the configured id) is necessary because if the filter is not perfect, group objects are picked up by the sync. Those don't have the dn (id).

Then some encoding stuff, because dn can apparently contain umlauts.