### PR TITLE
Fix a bug where the "show more" button was hidden erroneously.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a bug where the "show more" button was hidden erroneously. [mbaechtold]
 
 
 1.7.1 (2019-01-22)

--- a/ftw/contacts/resources/contactfolder_listing.js
+++ b/ftw/contacts/resources/contactfolder_listing.js
@@ -47,12 +47,20 @@ var ContactFolderListing = (function($) {
         }
     };
 
+    var req = null;
+
     var reloadView = function(reset) {
         reset = typeof reset !== 'undefined' ? reset : false;
         if (reset) {
             index = 0;
         }
-        $.getJSON('@@reload_contacts', {
+        if (req) {
+            // This prevents a strange race condition where "index" equals "steps",
+            // causing the more-button to be hidden even if there were more
+            // contacts to be displayed.
+            req.abort();
+        }
+        req = $.getJSON('@@reload_contacts', {
                 index_from: index,
                 index_to: index + step,
                 letter: letter,


### PR DESCRIPTION
A strange race condition caused the "show more" button to be hidden even if there were more contacts to be shown.

We prevent this by aborting pending AJAX requests to the "@@reload_contacts" view.