### PR TITLE
Fire different event in the sync script.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fire different event in the sync script. [mbaechtold]
 
 
 1.7.2 (2019-03-13)

--- a/ftw/contacts/sync/sync.py
+++ b/ftw/contacts/sync/sync.py
@@ -283,10 +283,10 @@ def sync_contacts(context, ldap_records, set_owner=False):
                 contact.manage_setLocalRoles(contact_id, ['Owner'])
                 contact.reindexObjectSecurity()
 
-            notify(ObjectAddedEvent(contact))
-
             aq_contact = context.get(contact_id)
             ct.catalog_object(aq_contact, '/'.join(aq_contact.getPhysicalPath()))
+
+            notify(ObjectAddedEvent(aq_contact))
 
             created += 1
             logger.debug("Created new contact '%s (%s)'." % (contact_id, dn))

--- a/ftw/contacts/sync/sync.py
+++ b/ftw/contacts/sync/sync.py
@@ -19,7 +19,7 @@ from zope.component import getUtility
 from zope.component import queryUtility
 from zope.container.interfaces import INameChooser
 from zope.event import notify
-from zope.lifecycleevent import ObjectCreatedEvent
+from zope.lifecycleevent import ObjectAddedEvent
 from zope.lifecycleevent import ObjectModifiedEvent
 from zope.schema import getFieldsInOrder
 from zope.site.hooks import setSite
@@ -283,7 +283,7 @@ def sync_contacts(context, ldap_records, set_owner=False):
                 contact.manage_setLocalRoles(contact_id, ['Owner'])
                 contact.reindexObjectSecurity()
 
-            notify(ObjectCreatedEvent(contact))
+            notify(ObjectAddedEvent(contact))
 
             aq_contact = context.get(contact_id)
             ct.catalog_object(aq_contact, '/'.join(aq_contact.getPhysicalPath()))


### PR DESCRIPTION
`ObjectCreatedEvent` is already fired in `plone.dexterity.utils.createContent()`, so we don't need to fire it again. But the real problem here is `plone.app.contentrules` not listening on `ObjectCreatedEvent` but rather `ObjectAddedEvent`.