### PR TITLE
Setup security in the in the sync script.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
+- Setup security in the in the sync script. [mbaechtold]
+
 - Fire different event in the sync script. [mbaechtold]
 
 

--- a/ftw/contacts/sync/sync.py
+++ b/ftw/contacts/sync/sync.py
@@ -1,3 +1,4 @@
+from AccessControl.SecurityManagement import newSecurityManager
 from ftw.contacts.contents.contact import IContactSchema
 from ftw.contacts.interfaces import IContact, IContactsSettings
 from ftw.contacts.interfaces import ILDAPAttributeMapper
@@ -81,6 +82,10 @@ def main():
         portal = app.unrestrictedTraverse(options.plone_site, None)
     if not portal:
         sys.exit("Plone site not found at %s" % options.plone_site)
+
+    user = portal.getOwner()
+    newSecurityManager(app, user)
+
     setSite(portal)
 
     # get the contact folder


### PR DESCRIPTION
This is required if we want to execute workflow actions through content rules.