### PR TITLE
Remove usage of spamProtect script, since it's no longer available in plone 5.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.9.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove usage of spamProtect script, since it's no longer available in plone 5. [mathias.leimgruber]
 
 
 1.9.3 (2020-01-09)

--- a/ftw/contacts/simplelayout/templates/member.pt
+++ b/ftw/contacts/simplelayout/templates/member.pt
@@ -36,6 +36,7 @@
                   <tr tal:condition="member/email">
                     <th><span i18n:translate="label_member_email">Email</span></th>
                     <td><span tal:content="structure python:context.spamProtect(mailaddress=member.email)" /></td>
+                    <td><span><a tal:attributes="href string:mailto:${member/email}" tal:content="member/email"></span></td>
                   </tr>
                   <tr tal:condition="member/www">
                     <th><span i18n:translate="label_member_www">www</span></th>


### PR DESCRIPTION
The script anyway did not help much to protext from any spam:


```
def escape(s):
	if s is not None:
		s = s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')
	return s

mailaddress = escape(mailaddress)
mailname = escape(mailname)
cssclass = escape(cssclass)
cssid = escape(cssid)

email = mailaddress.replace('@', '&#0064;').replace(':', '&#0058;')

if mailname is None:
    mailname = email
if cssid is None:
    cssid = ''
else:
    cssid = ' id="%s"' % cssid
if cssclass is None:
    cssclass = ''
else:
    cssclass = ' class="%s"' % cssclass

return '<a href="&#0109;ailto&#0058;' + email + '"' + cssclass \
        + cssid + '>' + mailname + '</a>'
```

