### PR TITLE
Fix contact renames

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.9.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix i18n build. [djowett-ftw]
 
 
 1.9.5 (2020-01-31)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Fix i18n build. [djowett-ftw]
+- Fix object_rename error by not trying to set Title field when renaming a Contact. [djowett-ftw]
 
 
 1.9.5 (2020-01-31)

--- a/ftw/contacts/__init__.py
+++ b/ftw/contacts/__init__.py
@@ -1,4 +1,6 @@
 from zope.i18nmessageid import MessageFactory
+import pkg_resources
 
 
 _ = MessageFactory('ftw.contacts')
+IS_PLONE_5 = pkg_resources.get_distribution('Products.CMFPlone').version >= '5'

--- a/ftw/contacts/browser/configure.zcml
+++ b/ftw/contacts/browser/configure.zcml
@@ -28,6 +28,14 @@
         />
 
     <browser:page
+        zcml:condition="have plone-5"
+        for="ftw.contacts.interfaces.IContact"
+        name="object_rename"
+        class=".contact.RenameForm"
+        permission="cmf.ModifyPortalContent"
+        />
+
+    <browser:page
         for="ftw.contacts.interfaces.IContactFolder"
         name="letters"
         class=".contactfolder.Letters"

--- a/ftw/contacts/browser/contact.py
+++ b/ftw/contacts/browser/contact.py
@@ -1,10 +1,17 @@
 from Acquisition import aq_inner, aq_parent
+from ftw.contacts import _
+from ftw.contacts import IS_PLONE_5
 from ftw.contacts.interfaces import IMemberBlock
 from ftw.contacts.utils import get_backreferences
 from ftw.contacts.utils import safe_html
 from ftw.contacts.utils import portrait_img_tag
 from plone import api
 from Products.Five.browser import BrowserView
+from z3c.form.interfaces import HIDDEN_MODE
+
+
+if IS_PLONE_5:
+    from plone.app.content.browser.actions import RenameForm as PloneRenameForm
 
 # Check for ftw.geo
 try:
@@ -81,3 +88,20 @@ class ContactSummary(BrowserView):
     @property
     def img_tag(self):
         return portrait_img_tag(self.context)
+
+
+if IS_PLONE_5:
+    class RenameForm(PloneRenameForm):
+        """ Plone's standard RenameForm will try to """
+
+        description = _(
+            u'description_rename_contact',
+            default=u"Each item has a Short Name which you can change by " +
+                    u"entering the new details below (Note that the 'Title' of " +
+                    u"a Contact is generated from other fields, so it can't be " +
+                    u"changed here)."
+        )
+
+        def updateWidgets(self):
+            super(RenameForm, self).updateWidgets()
+            self.widgets["new_title"].mode = HIDDEN_MODE

--- a/ftw/contacts/contents/contact.py
+++ b/ftw/contacts/contents/contact.py
@@ -263,5 +263,7 @@ class Contact(Item):
         """
         return get_contact_title(self)
 
-    def setTitle(self, value):
+    @title.setter
+    def title(self, value):
+        # This method is necessary for rename(), but we ignore the value passed
         return

--- a/ftw/contacts/locales/de/LC_MESSAGES/ftw.contacts.po
+++ b/ftw/contacts/locales/de/LC_MESSAGES/ftw.contacts.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-15 08:26+0000\n"
+"POT-Creation-Date: 2020-02-13 13:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,10 +15,12 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 
 #: ./ftw/contacts/profiles/default/types/ftw.contacts.Contact.xml
+#: ./ftw/contacts/profiles/default_plone5/types/ftw.contacts.Contact.xml
 msgid "Contact"
 msgstr "Kontakt"
 
 #: ./ftw/contacts/profiles/default/types/ftw.contacts.ContactFolder.xml
+#: ./ftw/contacts/profiles/default_plone5/types/ftw.contacts.ContactFolder.xml
 msgid "ContactFolder"
 msgstr "Kontaktordner"
 
@@ -27,10 +29,12 @@ msgid "Contacts Path"
 msgstr ""
 
 #: ./ftw/contacts/profiles/default/actions.xml
+#: ./ftw/contacts/profiles/default_plone5/actions.xml
 msgid "Download a Contact as a vCard."
 msgstr "Kontakt als vCard herunterladen"
 
 #: ./ftw/contacts/profiles/default/actions.xml
+#: ./ftw/contacts/profiles/default_plone5/actions.xml
 msgid "Download vCard"
 msgstr "vCard herunterladen"
 
@@ -43,6 +47,7 @@ msgid "LDAP Plugin ID"
 msgstr ""
 
 #: ./ftw/contacts/simplelayout/profiles/default/types/ftw.contacts.MemberBlock.xml
+#: ./ftw/contacts/simplelayout/profiles/default_plone5/types/ftw.contacts.MemberBlock.xml
 msgid "MemberBlock"
 msgstr "Mitgliedblock"
 
@@ -55,8 +60,9 @@ msgstr ""
 msgid "description_function"
 msgstr "Wird angezeigt auch wenn die Adresse übernommen wird und beim Kontakt eine Funktion hinterlegt ist."
 
-#. Default: "If activated, the images of the contacts are not shown."
-#: ./ftw/contacts/contents/contactfolder.py:16
+#. Default: "If activated, the images of the contacts are not shown in the listing-view."
+#: ./ftw/contacts/contents/contactfolder.py:17
+#, fuzzy
 msgid "help_contactdirectory_hide_contacts_image"
 msgstr "Wenn aktivert, werden die Bilder der Kontakte in der Auflistungs-Ansicht nicht angezeigt."
 
@@ -66,14 +72,14 @@ msgid "label_academic_title"
 msgstr "Akademischer Titel"
 
 #. Default: "Acquire address"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:73
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:63
 msgid "label_acquire_address"
 msgstr "Adresse von Stammdaten übernehmen"
 
 #. Default: "Address"
 #: ./ftw/contacts/browser/templates/contact.pt:75
 #: ./ftw/contacts/contents/contact.py:63
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:78
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:68
 msgid "label_address"
 msgstr "Adresse"
 
@@ -84,7 +90,7 @@ msgstr "Adresse"
 
 #. Default: "City"
 #: ./ftw/contacts/contents/contact.py:77
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:92
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:82
 msgid "label_city"
 msgstr "Ort"
 
@@ -95,13 +101,13 @@ msgstr "Ort"
 
 #. Default: "The related contact does no longer exists."
 #: ./ftw/contacts/simplelayout/templates/member.pt:70
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:50
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:63
 msgid "label_contact_does_no_longer_exists"
 msgstr "Der dazugehörige Kontakt existiert nicht mehr."
 
 #. Default: "Delete this content or edit it to replace the deleted with an existing contact"
 #: ./ftw/contacts/simplelayout/templates/member.pt:71
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:51
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:64
 msgid "label_contact_does_no_longer_exists_hint"
 msgstr "Bitte weisen Sie diesem Mitglied einen neuen Kontakt hinzu oder löschen sie dieses."
 
@@ -111,7 +117,7 @@ msgid "label_contact_more"
 msgstr "Kontakt"
 
 #. Default: "Contact reference"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:53
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:44
 msgid "label_contact_reference"
 msgstr "Stammdaten Kontakt"
 
@@ -134,14 +140,14 @@ msgstr "Abteilung"
 #. Default: "E-Mail"
 #: ./ftw/contacts/browser/templates/contact.pt:95
 #: ./ftw/contacts/contents/contact.py:90
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:99
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:89
 msgid "label_email"
 msgstr "E-Mail"
 
 #. Default: "Fax number"
 #: ./ftw/contacts/browser/templates/contact.pt:91
 #: ./ftw/contacts/contents/contact.py:110
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:119
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:109
 msgid "label_fax"
 msgstr "Fax"
 
@@ -151,7 +157,7 @@ msgid "label_female"
 msgstr "Frau"
 
 #. Default: "Contact"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:131
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:121
 msgid "label_fieldset_contact"
 msgstr "Kontakt"
 
@@ -173,7 +179,7 @@ msgstr "Vorname"
 #. Default: "Function"
 #: ./ftw/contacts/browser/templates/contact.pt:63
 #: ./ftw/contacts/contents/contact.py:133
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:59
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:49
 msgid "label_function"
 msgstr "Funktion"
 
@@ -248,7 +254,7 @@ msgid "label_member_www"
 msgstr "Url"
 
 #. Default: "Memberships"
-#: ./ftw/contacts/browser/templates/contact.pt:132
+#: ./ftw/contacts/browser/templates/contact.pt:133
 msgid "label_memberships"
 msgstr "Mitgliedschaften"
 
@@ -267,14 +273,14 @@ msgstr "Organisation"
 #. Default: "Mobile phone number"
 #: ./ftw/contacts/browser/templates/contact.pt:87
 #: ./ftw/contacts/contents/contact.py:103
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:112
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:102
 msgid "label_phone_mobile"
 msgstr "Telefon mobil"
 
 #. Default: "Office phone number"
 #: ./ftw/contacts/browser/templates/contact.pt:83
 #: ./ftw/contacts/contents/contact.py:96
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:105
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:95
 msgid "label_phone_office"
 msgstr "Telefon geschäftlich"
 
@@ -286,7 +292,7 @@ msgstr "Telefon privat"
 
 #. Default: "Postal code"
 #: ./ftw/contacts/contents/contact.py:70
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:85
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:75
 msgid "label_postal_code"
 msgstr "PLZ"
 
@@ -301,44 +307,44 @@ msgid "label_salutation"
 msgstr "Begrüssung"
 
 #. Default: "Fax"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:38
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:49
 msgid "label_short_fax"
 msgstr "Fax"
 
 #. Default: "Mobile"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:34
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:44
 msgid "label_short_mobile"
 msgstr "Mobile"
 
 #. Default: "Office"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:30
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:39
 msgid "label_short_office"
 msgstr "Geschäft"
 
 #. Default: "phone m"
-#: ./ftw/contacts/browser/templates/contact_summary.pt:37
+#: ./ftw/contacts/browser/templates/contact_summary.pt:38
 #, fuzzy
 msgid "label_short_phone_mobile"
 msgstr "Telefon mobile:"
 
 #. Default: "phone o"
-#: ./ftw/contacts/browser/templates/contact_summary.pt:28
+#: ./ftw/contacts/browser/templates/contact_summary.pt:29
 #, fuzzy
 msgid "label_short_phone_office"
 msgstr "Telefon geschäftlich:"
 
 #. Default: "Show address"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:65
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:55
 msgid "label_show_address"
 msgstr "Adresse anzeigen"
 
 #. Default: "Show image"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:69
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:59
 msgid "label_show_image"
 msgstr "Bild anzeigen"
 
 #. Default: "Show title"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:49
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:38
 msgid "label_show_title"
 msgstr "Titel anzeigen"
 
@@ -348,7 +354,7 @@ msgid "label_text"
 msgstr "Text"
 
 #. Default: "Title"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:43
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:32
 msgid "label_title"
 msgstr "Titel"
 
@@ -360,7 +366,7 @@ msgstr ""
 #. Default: "www"
 #: ./ftw/contacts/browser/templates/contact.pt:102
 #: ./ftw/contacts/contents/contact.py:116
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:125
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:115
 msgid "label_www"
 msgstr "URL"
 

--- a/ftw/contacts/locales/de/LC_MESSAGES/ftw.contacts.po
+++ b/ftw/contacts/locales/de/LC_MESSAGES/ftw.contacts.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-02-13 13:04+0000\n"
+"POT-Creation-Date: 2020-02-13 13:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,6 +59,11 @@ msgstr ""
 #: ./ftw/contacts/contents/contact.py:134
 msgid "description_function"
 msgstr "Wird angezeigt auch wenn die Adresse übernommen wird und beim Kontakt eine Funktion hinterlegt ist."
+
+#. Default: "Each item has a Short Name which you can change by entering the new details below (Note that the 'Title' of a Contact is generated from other fields, so it can't be changed here)."
+#: ./ftw/contacts/browser/contact.py:94
+msgid "description_rename_contact"
+msgstr "Jeder Inhalt hat einen Namen und einen Titel, die Sie durch erneute Eingabe ändern können. (Beachten Sie, dass der 'Titel' eines Kontakts aus anderen Feldern generiert wird, somit kann er hier nicht geändert werden."
 
 #. Default: "If activated, the images of the contacts are not shown in the listing-view."
 #: ./ftw/contacts/contents/contactfolder.py:17

--- a/ftw/contacts/locales/fr/LC_MESSAGES/ftw.contacts.po
+++ b/ftw/contacts/locales/fr/LC_MESSAGES/ftw.contacts.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-02-13 13:04+0000\n"
+"POT-Creation-Date: 2020-02-13 13:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,6 +58,11 @@ msgstr ""
 #. Default: "Will be displayed even if the address is acquired and the contact has a function."
 #: ./ftw/contacts/contents/contact.py:134
 msgid "description_function"
+msgstr ""
+
+#. Default: "Each item has a Short Name which you can change by entering the new details below (Note that the 'Title' of a Contact is generated from other fields, so it can't be changed here)."
+#: ./ftw/contacts/browser/contact.py:94
+msgid "description_rename_contact"
 msgstr ""
 
 #. Default: "If activated, the images of the contacts are not shown in the listing-view."

--- a/ftw/contacts/locales/fr/LC_MESSAGES/ftw.contacts.po
+++ b/ftw/contacts/locales/fr/LC_MESSAGES/ftw.contacts.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-15 08:26+0000\n"
+"POT-Creation-Date: 2020-02-13 13:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,10 +15,12 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 
 #: ./ftw/contacts/profiles/default/types/ftw.contacts.Contact.xml
+#: ./ftw/contacts/profiles/default_plone5/types/ftw.contacts.Contact.xml
 msgid "Contact"
 msgstr "Contact"
 
 #: ./ftw/contacts/profiles/default/types/ftw.contacts.ContactFolder.xml
+#: ./ftw/contacts/profiles/default_plone5/types/ftw.contacts.ContactFolder.xml
 msgid "ContactFolder"
 msgstr "Contact dossier"
 
@@ -27,10 +29,12 @@ msgid "Contacts Path"
 msgstr ""
 
 #: ./ftw/contacts/profiles/default/actions.xml
+#: ./ftw/contacts/profiles/default_plone5/actions.xml
 msgid "Download a Contact as a vCard."
 msgstr "Télécharger un contact comme vCard."
 
 #: ./ftw/contacts/profiles/default/actions.xml
+#: ./ftw/contacts/profiles/default_plone5/actions.xml
 msgid "Download vCard"
 msgstr "Télécharger vCard"
 
@@ -43,6 +47,7 @@ msgid "LDAP Plugin ID"
 msgstr ""
 
 #: ./ftw/contacts/simplelayout/profiles/default/types/ftw.contacts.MemberBlock.xml
+#: ./ftw/contacts/simplelayout/profiles/default_plone5/types/ftw.contacts.MemberBlock.xml
 msgid "MemberBlock"
 msgstr "Block member"
 
@@ -55,8 +60,9 @@ msgstr ""
 msgid "description_function"
 msgstr ""
 
-#. Default: "If activated, the images of the contacts are not shown."
-#: ./ftw/contacts/contents/contactfolder.py:16
+#. Default: "If activated, the images of the contacts are not shown in the listing-view."
+#: ./ftw/contacts/contents/contactfolder.py:17
+#, fuzzy
 msgid "help_contactdirectory_hide_contacts_image"
 msgstr "Si activé, les images des contacts ne sont pas affichées."
 
@@ -66,14 +72,14 @@ msgid "label_academic_title"
 msgstr "Titre académique"
 
 #. Default: "Acquire address"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:73
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:63
 msgid "label_acquire_address"
 msgstr "Acquérir adresse"
 
 #. Default: "Address"
 #: ./ftw/contacts/browser/templates/contact.pt:75
 #: ./ftw/contacts/contents/contact.py:63
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:78
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:68
 msgid "label_address"
 msgstr "Adresse"
 
@@ -84,7 +90,7 @@ msgstr "Adresse"
 
 #. Default: "City"
 #: ./ftw/contacts/contents/contact.py:77
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:92
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:82
 msgid "label_city"
 msgstr "Ville"
 
@@ -95,13 +101,13 @@ msgstr "Ville"
 
 #. Default: "The related contact does no longer exists."
 #: ./ftw/contacts/simplelayout/templates/member.pt:70
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:50
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:63
 msgid "label_contact_does_no_longer_exists"
 msgstr "Le contact associé n'existe plus."
 
 #. Default: "Delete this content or edit it to replace the deleted with an existing contact"
 #: ./ftw/contacts/simplelayout/templates/member.pt:71
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:51
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:64
 msgid "label_contact_does_no_longer_exists_hint"
 msgstr "Supprimer ce contenu ou le modifier pour remplacer la suppression d'un contact existant"
 
@@ -111,7 +117,7 @@ msgid "label_contact_more"
 msgstr "Contact"
 
 #. Default: "Contact reference"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:53
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:44
 msgid "label_contact_reference"
 msgstr "Référence de contact"
 
@@ -134,14 +140,14 @@ msgstr "Departement"
 #. Default: "E-Mail"
 #: ./ftw/contacts/browser/templates/contact.pt:95
 #: ./ftw/contacts/contents/contact.py:90
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:99
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:89
 msgid "label_email"
 msgstr "E-Mail"
 
 #. Default: "Fax number"
 #: ./ftw/contacts/browser/templates/contact.pt:91
 #: ./ftw/contacts/contents/contact.py:110
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:119
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:109
 msgid "label_fax"
 msgstr "Numéro de fax"
 
@@ -151,7 +157,7 @@ msgid "label_female"
 msgstr "Femelle"
 
 #. Default: "Contact"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:131
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:121
 msgid "label_fieldset_contact"
 msgstr "Contact"
 
@@ -173,7 +179,7 @@ msgstr "Prénom"
 #. Default: "Function"
 #: ./ftw/contacts/browser/templates/contact.pt:63
 #: ./ftw/contacts/contents/contact.py:133
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:59
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:49
 msgid "label_function"
 msgstr "Fonction"
 
@@ -248,7 +254,7 @@ msgid "label_member_www"
 msgstr "www"
 
 #. Default: "Memberships"
-#: ./ftw/contacts/browser/templates/contact.pt:132
+#: ./ftw/contacts/browser/templates/contact.pt:133
 msgid "label_memberships"
 msgstr "Adhésions"
 
@@ -267,14 +273,14 @@ msgstr "Organisation"
 #. Default: "Mobile phone number"
 #: ./ftw/contacts/browser/templates/contact.pt:87
 #: ./ftw/contacts/contents/contact.py:103
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:112
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:102
 msgid "label_phone_mobile"
 msgstr "Numéro de portable"
 
 #. Default: "Office phone number"
 #: ./ftw/contacts/browser/templates/contact.pt:83
 #: ./ftw/contacts/contents/contact.py:96
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:105
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:95
 msgid "label_phone_office"
 msgstr "Numéro de téléphone de bureau"
 
@@ -286,7 +292,7 @@ msgstr "Numéro de téléphone privé"
 
 #. Default: "Postal code"
 #: ./ftw/contacts/contents/contact.py:70
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:85
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:75
 msgid "label_postal_code"
 msgstr "Code postal"
 
@@ -301,44 +307,44 @@ msgid "label_salutation"
 msgstr "Salutation"
 
 #. Default: "Fax"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:38
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:49
 msgid "label_short_fax"
 msgstr "Fax"
 
 #. Default: "Mobile"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:34
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:44
 msgid "label_short_mobile"
 msgstr "Mobile"
 
 #. Default: "Office"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:30
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:39
 msgid "label_short_office"
 msgstr "Bureau"
 
 #. Default: "phone m"
-#: ./ftw/contacts/browser/templates/contact_summary.pt:37
+#: ./ftw/contacts/browser/templates/contact_summary.pt:38
 #, fuzzy
 msgid "label_short_phone_mobile"
 msgstr "Téléphone portable"
 
 #. Default: "phone o"
-#: ./ftw/contacts/browser/templates/contact_summary.pt:28
+#: ./ftw/contacts/browser/templates/contact_summary.pt:29
 #, fuzzy
 msgid "label_short_phone_office"
 msgstr "Téléphone bureau"
 
 #. Default: "Show address"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:65
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:55
 msgid "label_show_address"
 msgstr "Afficher l'adresse"
 
 #. Default: "Show image"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:69
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:59
 msgid "label_show_image"
 msgstr "Voir l'image"
 
 #. Default: "Show title"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:49
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:38
 msgid "label_show_title"
 msgstr "Montrer le titre"
 
@@ -348,7 +354,7 @@ msgid "label_text"
 msgstr "Texte"
 
 #. Default: "Title"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:43
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:32
 msgid "label_title"
 msgstr "Titre"
 
@@ -360,7 +366,7 @@ msgstr ""
 #. Default: "www"
 #: ./ftw/contacts/browser/templates/contact.pt:102
 #: ./ftw/contacts/contents/contact.py:116
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:125
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:115
 msgid "label_www"
 msgstr "www"
 

--- a/ftw/contacts/locales/ftw.contacts.pot
+++ b/ftw/contacts/locales/ftw.contacts.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-02-13 13:04+0000\n"
+"POT-Creation-Date: 2020-02-13 13:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,6 +58,11 @@ msgstr ""
 #. Default: "Will be displayed even if the address is acquired and the contact has a function."
 #: ./ftw/contacts/contents/contact.py:134
 msgid "description_function"
+msgstr ""
+
+#. Default: "Each item has a Short Name which you can change by entering the new details below (Note that the 'Title' of a Contact is generated from other fields, so it can't be changed here)."
+#: ./ftw/contacts/browser/contact.py:94
+msgid "description_rename_contact"
 msgstr ""
 
 #. Default: "If activated, the images of the contacts are not shown in the listing-view."

--- a/ftw/contacts/locales/ftw.contacts.pot
+++ b/ftw/contacts/locales/ftw.contacts.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-15 08:26+0000\n"
+"POT-Creation-Date: 2020-02-13 13:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,10 +15,12 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 
 #: ./ftw/contacts/profiles/default/types/ftw.contacts.Contact.xml
+#: ./ftw/contacts/profiles/default_plone5/types/ftw.contacts.Contact.xml
 msgid "Contact"
 msgstr ""
 
 #: ./ftw/contacts/profiles/default/types/ftw.contacts.ContactFolder.xml
+#: ./ftw/contacts/profiles/default_plone5/types/ftw.contacts.ContactFolder.xml
 msgid "ContactFolder"
 msgstr ""
 
@@ -27,10 +29,12 @@ msgid "Contacts Path"
 msgstr ""
 
 #: ./ftw/contacts/profiles/default/actions.xml
+#: ./ftw/contacts/profiles/default_plone5/actions.xml
 msgid "Download a Contact as a vCard."
 msgstr ""
 
 #: ./ftw/contacts/profiles/default/actions.xml
+#: ./ftw/contacts/profiles/default_plone5/actions.xml
 msgid "Download vCard"
 msgstr ""
 
@@ -43,6 +47,7 @@ msgid "LDAP Plugin ID"
 msgstr ""
 
 #: ./ftw/contacts/simplelayout/profiles/default/types/ftw.contacts.MemberBlock.xml
+#: ./ftw/contacts/simplelayout/profiles/default_plone5/types/ftw.contacts.MemberBlock.xml
 msgid "MemberBlock"
 msgstr ""
 
@@ -55,8 +60,8 @@ msgstr ""
 msgid "description_function"
 msgstr ""
 
-#. Default: "If activated, the images of the contacts are not shown."
-#: ./ftw/contacts/contents/contactfolder.py:16
+#. Default: "If activated, the images of the contacts are not shown in the listing-view."
+#: ./ftw/contacts/contents/contactfolder.py:17
 msgid "help_contactdirectory_hide_contacts_image"
 msgstr ""
 
@@ -66,14 +71,14 @@ msgid "label_academic_title"
 msgstr ""
 
 #. Default: "Acquire address"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:73
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:63
 msgid "label_acquire_address"
 msgstr ""
 
 #. Default: "Address"
 #: ./ftw/contacts/browser/templates/contact.pt:75
 #: ./ftw/contacts/contents/contact.py:63
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:78
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:68
 msgid "label_address"
 msgstr ""
 
@@ -84,7 +89,7 @@ msgstr ""
 
 #. Default: "City"
 #: ./ftw/contacts/contents/contact.py:77
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:92
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:82
 msgid "label_city"
 msgstr ""
 
@@ -95,13 +100,13 @@ msgstr ""
 
 #. Default: "The related contact does no longer exists."
 #: ./ftw/contacts/simplelayout/templates/member.pt:70
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:50
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:63
 msgid "label_contact_does_no_longer_exists"
 msgstr ""
 
 #. Default: "Delete this content or edit it to replace the deleted with an existing contact"
 #: ./ftw/contacts/simplelayout/templates/member.pt:71
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:51
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:64
 msgid "label_contact_does_no_longer_exists_hint"
 msgstr ""
 
@@ -111,7 +116,7 @@ msgid "label_contact_more"
 msgstr ""
 
 #. Default: "Contact reference"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:53
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:44
 msgid "label_contact_reference"
 msgstr ""
 
@@ -134,14 +139,14 @@ msgstr ""
 #. Default: "E-Mail"
 #: ./ftw/contacts/browser/templates/contact.pt:95
 #: ./ftw/contacts/contents/contact.py:90
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:99
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:89
 msgid "label_email"
 msgstr ""
 
 #. Default: "Fax number"
 #: ./ftw/contacts/browser/templates/contact.pt:91
 #: ./ftw/contacts/contents/contact.py:110
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:119
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:109
 msgid "label_fax"
 msgstr ""
 
@@ -151,7 +156,7 @@ msgid "label_female"
 msgstr ""
 
 #. Default: "Contact"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:131
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:121
 msgid "label_fieldset_contact"
 msgstr ""
 
@@ -173,7 +178,7 @@ msgstr ""
 #. Default: "Function"
 #: ./ftw/contacts/browser/templates/contact.pt:63
 #: ./ftw/contacts/contents/contact.py:133
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:59
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:49
 msgid "label_function"
 msgstr ""
 
@@ -248,7 +253,7 @@ msgid "label_member_www"
 msgstr ""
 
 #. Default: "Memberships"
-#: ./ftw/contacts/browser/templates/contact.pt:132
+#: ./ftw/contacts/browser/templates/contact.pt:133
 msgid "label_memberships"
 msgstr ""
 
@@ -266,14 +271,14 @@ msgstr ""
 #. Default: "Mobile phone number"
 #: ./ftw/contacts/browser/templates/contact.pt:87
 #: ./ftw/contacts/contents/contact.py:103
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:112
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:102
 msgid "label_phone_mobile"
 msgstr ""
 
 #. Default: "Office phone number"
 #: ./ftw/contacts/browser/templates/contact.pt:83
 #: ./ftw/contacts/contents/contact.py:96
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:105
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:95
 msgid "label_phone_office"
 msgstr ""
 
@@ -285,7 +290,7 @@ msgstr ""
 
 #. Default: "Postal code"
 #: ./ftw/contacts/contents/contact.py:70
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:85
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:75
 msgid "label_postal_code"
 msgstr ""
 
@@ -300,42 +305,42 @@ msgid "label_salutation"
 msgstr ""
 
 #. Default: "Fax"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:38
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:49
 msgid "label_short_fax"
 msgstr ""
 
 #. Default: "Mobile"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:34
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:44
 msgid "label_short_mobile"
 msgstr ""
 
 #. Default: "Office"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:30
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:39
 msgid "label_short_office"
 msgstr ""
 
 #. Default: "phone m"
-#: ./ftw/contacts/browser/templates/contact_summary.pt:37
+#: ./ftw/contacts/browser/templates/contact_summary.pt:38
 msgid "label_short_phone_mobile"
 msgstr ""
 
 #. Default: "phone o"
-#: ./ftw/contacts/browser/templates/contact_summary.pt:28
+#: ./ftw/contacts/browser/templates/contact_summary.pt:29
 msgid "label_short_phone_office"
 msgstr ""
 
 #. Default: "Show address"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:65
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:55
 msgid "label_show_address"
 msgstr ""
 
 #. Default: "Show image"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:69
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:59
 msgid "label_show_image"
 msgstr ""
 
 #. Default: "Show title"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:49
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:38
 msgid "label_show_title"
 msgstr ""
 
@@ -345,7 +350,7 @@ msgid "label_text"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:43
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:32
 msgid "label_title"
 msgstr ""
 
@@ -357,7 +362,7 @@ msgstr ""
 #. Default: "www"
 #: ./ftw/contacts/browser/templates/contact.pt:102
 #: ./ftw/contacts/contents/contact.py:116
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:125
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:115
 msgid "label_www"
 msgstr ""
 

--- a/ftw/contacts/locales/it/LC_MESSAGES/ftw.contacts.po
+++ b/ftw/contacts/locales/it/LC_MESSAGES/ftw.contacts.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-02-13 13:04+0000\n"
+"POT-Creation-Date: 2020-02-13 13:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,6 +58,11 @@ msgstr ""
 #. Default: "Will be displayed even if the address is acquired and the contact has a function."
 #: ./ftw/contacts/contents/contact.py:134
 msgid "description_function"
+msgstr ""
+
+#. Default: "Each item has a Short Name which you can change by entering the new details below (Note that the 'Title' of a Contact is generated from other fields, so it can't be changed here)."
+#: ./ftw/contacts/browser/contact.py:94
+msgid "description_rename_contact"
 msgstr ""
 
 #. Default: "If activated, the images of the contacts are not shown in the listing-view."

--- a/ftw/contacts/locales/it/LC_MESSAGES/ftw.contacts.po
+++ b/ftw/contacts/locales/it/LC_MESSAGES/ftw.contacts.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-15 08:26+0000\n"
+"POT-Creation-Date: 2020-02-13 13:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,10 +15,12 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 
 #: ./ftw/contacts/profiles/default/types/ftw.contacts.Contact.xml
+#: ./ftw/contacts/profiles/default_plone5/types/ftw.contacts.Contact.xml
 msgid "Contact"
 msgstr "Contatto"
 
 #: ./ftw/contacts/profiles/default/types/ftw.contacts.ContactFolder.xml
+#: ./ftw/contacts/profiles/default_plone5/types/ftw.contacts.ContactFolder.xml
 msgid "ContactFolder"
 msgstr "Cartella contatto"
 
@@ -27,10 +29,12 @@ msgid "Contacts Path"
 msgstr ""
 
 #: ./ftw/contacts/profiles/default/actions.xml
+#: ./ftw/contacts/profiles/default_plone5/actions.xml
 msgid "Download a Contact as a vCard."
 msgstr "Scarica un contatto come vCard."
 
 #: ./ftw/contacts/profiles/default/actions.xml
+#: ./ftw/contacts/profiles/default_plone5/actions.xml
 msgid "Download vCard"
 msgstr "Scarica vCard"
 
@@ -43,6 +47,7 @@ msgid "LDAP Plugin ID"
 msgstr ""
 
 #: ./ftw/contacts/simplelayout/profiles/default/types/ftw.contacts.MemberBlock.xml
+#: ./ftw/contacts/simplelayout/profiles/default_plone5/types/ftw.contacts.MemberBlock.xml
 msgid "MemberBlock"
 msgstr "Blocco membro"
 
@@ -55,8 +60,9 @@ msgstr ""
 msgid "description_function"
 msgstr ""
 
-#. Default: "If activated, the images of the contacts are not shown."
-#: ./ftw/contacts/contents/contactfolder.py:16
+#. Default: "If activated, the images of the contacts are not shown in the listing-view."
+#: ./ftw/contacts/contents/contactfolder.py:17
+#, fuzzy
 msgid "help_contactdirectory_hide_contacts_image"
 msgstr "Se attivata, le immagini dei contatti non vengono visualizzate."
 
@@ -66,14 +72,14 @@ msgid "label_academic_title"
 msgstr "Titolo accademico"
 
 #. Default: "Acquire address"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:73
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:63
 msgid "label_acquire_address"
 msgstr "Acquisire indirizzo"
 
 #. Default: "Address"
 #: ./ftw/contacts/browser/templates/contact.pt:75
 #: ./ftw/contacts/contents/contact.py:63
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:78
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:68
 msgid "label_address"
 msgstr "Indirizzo"
 
@@ -84,7 +90,7 @@ msgstr "Indirizzo"
 
 #. Default: "City"
 #: ./ftw/contacts/contents/contact.py:77
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:92
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:82
 msgid "label_city"
 msgstr "Città"
 
@@ -95,13 +101,13 @@ msgstr "Città"
 
 #. Default: "The related contact does no longer exists."
 #: ./ftw/contacts/simplelayout/templates/member.pt:70
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:50
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:63
 msgid "label_contact_does_no_longer_exists"
 msgstr "Il contatto non è più correlato non esiste."
 
 #. Default: "Delete this content or edit it to replace the deleted with an existing contact"
 #: ./ftw/contacts/simplelayout/templates/member.pt:71
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:51
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:64
 msgid "label_contact_does_no_longer_exists_hint"
 msgstr "Eliminare questo contenuto o modificarlo per sostituire la cancellata con un contatto esistente"
 
@@ -111,7 +117,7 @@ msgid "label_contact_more"
 msgstr "Contatto"
 
 #. Default: "Contact reference"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:53
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:44
 msgid "label_contact_reference"
 msgstr "Contatto di riferimento"
 
@@ -134,14 +140,14 @@ msgstr "Dipartimento"
 #. Default: "E-Mail"
 #: ./ftw/contacts/browser/templates/contact.pt:95
 #: ./ftw/contacts/contents/contact.py:90
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:99
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:89
 msgid "label_email"
 msgstr "E-Mail"
 
 #. Default: "Fax number"
 #: ./ftw/contacts/browser/templates/contact.pt:91
 #: ./ftw/contacts/contents/contact.py:110
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:119
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:109
 msgid "label_fax"
 msgstr "Numero di fax"
 
@@ -151,7 +157,7 @@ msgid "label_female"
 msgstr "Femmina"
 
 #. Default: "Contact"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:131
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:121
 msgid "label_fieldset_contact"
 msgstr "Contatto"
 
@@ -173,7 +179,7 @@ msgstr "Nome"
 #. Default: "Function"
 #: ./ftw/contacts/browser/templates/contact.pt:63
 #: ./ftw/contacts/contents/contact.py:133
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:59
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:49
 msgid "label_function"
 msgstr "Funzione"
 
@@ -248,7 +254,7 @@ msgid "label_member_www"
 msgstr "www"
 
 #. Default: "Memberships"
-#: ./ftw/contacts/browser/templates/contact.pt:132
+#: ./ftw/contacts/browser/templates/contact.pt:133
 msgid "label_memberships"
 msgstr "Membri"
 
@@ -267,14 +273,14 @@ msgstr "Organizzazione"
 #. Default: "Mobile phone number"
 #: ./ftw/contacts/browser/templates/contact.pt:87
 #: ./ftw/contacts/contents/contact.py:103
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:112
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:102
 msgid "label_phone_mobile"
 msgstr "Numero di cellulare"
 
 #. Default: "Office phone number"
 #: ./ftw/contacts/browser/templates/contact.pt:83
 #: ./ftw/contacts/contents/contact.py:96
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:105
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:95
 msgid "label_phone_office"
 msgstr "Numero di telefono dell'ufficio"
 
@@ -286,7 +292,7 @@ msgstr "Numero di telefono privato"
 
 #. Default: "Postal code"
 #: ./ftw/contacts/contents/contact.py:70
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:85
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:75
 msgid "label_postal_code"
 msgstr "Codice postale"
 
@@ -301,44 +307,44 @@ msgid "label_salutation"
 msgstr "Saluto"
 
 #. Default: "Fax"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:38
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:49
 msgid "label_short_fax"
 msgstr "Fax"
 
 #. Default: "Mobile"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:34
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:44
 msgid "label_short_mobile"
 msgstr "Cellulare"
 
 #. Default: "Office"
-#: ./ftw/contacts/simplelayout/templates/memberblock.pt:30
+#: ./ftw/contacts/simplelayout/templates/memberblock.pt:39
 msgid "label_short_office"
 msgstr "Ufficio"
 
 #. Default: "phone m"
-#: ./ftw/contacts/browser/templates/contact_summary.pt:37
+#: ./ftw/contacts/browser/templates/contact_summary.pt:38
 #, fuzzy
 msgid "label_short_phone_mobile"
 msgstr "Cellulare"
 
 #. Default: "phone o"
-#: ./ftw/contacts/browser/templates/contact_summary.pt:28
+#: ./ftw/contacts/browser/templates/contact_summary.pt:29
 #, fuzzy
 msgid "label_short_phone_office"
 msgstr "Telefono ufficio"
 
 #. Default: "Show address"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:65
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:55
 msgid "label_show_address"
 msgstr "Mostra indirizzo"
 
 #. Default: "Show image"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:69
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:59
 msgid "label_show_image"
 msgstr "Mostra immagine"
 
 #. Default: "Show title"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:49
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:38
 msgid "label_show_title"
 msgstr "Mostra titolo"
 
@@ -348,7 +354,7 @@ msgid "label_text"
 msgstr "Testo"
 
 #. Default: "Title"
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:43
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:32
 msgid "label_title"
 msgstr "Titolo"
 
@@ -360,7 +366,7 @@ msgstr ""
 #. Default: "www"
 #: ./ftw/contacts/browser/templates/contact.pt:102
 #: ./ftw/contacts/contents/contact.py:116
-#: ./ftw/contacts/simplelayout/contents/memberblock.py:125
+#: ./ftw/contacts/simplelayout/contents/memberblock.py:115
 msgid "label_www"
 msgstr "www"
 

--- a/ftw/contacts/simplelayout/templates/member.pt
+++ b/ftw/contacts/simplelayout/templates/member.pt
@@ -35,7 +35,7 @@
                   </tr>
                   <tr tal:condition="member/email">
                     <th><span i18n:translate="label_member_email">Email</span></th>
-                    <td><span><a tal:attributes="href string:mailto:${member/email}" tal:content="member/email"></span></td>
+                    <td><span><a tal:attributes="href string:mailto:${member/email}" tal:content="member/email" /></span></td>
                   </tr>
                   <tr tal:condition="member/www">
                     <th><span i18n:translate="label_member_www">www</span></th>


### PR DESCRIPTION
Resolves issue in Plone 5 where rename popup doesn't work.

Resolves https://github.com/4teamwork/izug.organisation/issues/1895

This also hides the Title field in the Plone 5 object_rename form to save user confusion.

This _doesn't_ hide the Title field for the popup in folder_contents - that is much more involved (and doesn't seem to be used by our customer)