### PR TITLE
Strip ldap synced values

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Strip ldap synced values [Nachtalb]
 
 
 1.10.0 (2020-02-20)

--- a/ftw/contacts/sync/sync.py
+++ b/ftw/contacts/sync/sync.py
@@ -265,6 +265,9 @@ def sync_contacts(context, ldap_records, set_owner=False):
             if IBlobWrapper.providedBy(current_value):
                 current_value = current_value.data
 
+            if isinstance(value, basestring):
+                value = value.strip()
+
             if current_value != value:
                 # Handle images
                 if INamedImageField.providedBy(field) and value:


### PR DESCRIPTION
An LDAP-sync had values which were just strings with whitespaces. And we generally don't want values purely existing out of newlines/whitespaces because they are true-ish in python but are basically empty, it only generates problems. And additionally, it doesn't make sense to have trailing whitespaces/newlines either. 