### PR TITLE
Pin geopy to Python2 compatible version.

### DIFF
--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -17,3 +17,6 @@ collective.z3cform.colorpicker = 2.0
 collective.z3cform.mapwidget = 2.2
 
 python-ldap = 2.4.25
+
+# geopy >= 2 only supports python 3
+geopy = <2a


### PR DESCRIPTION
If geopy was unpinned buildout would get the most recent version of geopy which is not Python 2.7 compatible anymore.