### PR TITLE
Fix broken contentpage with memberblock

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Remove obsolete behaviour in Plone 5 [Nachtalb]
+- Fix broken contentpage containing a memberblock [Nachtalb]
 
 
 1.10.2 (2020-08-04)

--- a/ftw/contacts/simplelayout/memberblock.py
+++ b/ftw/contacts/simplelayout/memberblock.py
@@ -9,14 +9,6 @@ class MemberBlockView(BaseBlock, MemberView):
 
     template = ViewPageTemplateFile('templates/memberblock.pt')
 
-    def __call__(self):
-        # Partial views are encoded wrong when not called by ajax in plone 5.
-        # In consequece in tests, encoding errors can appear if we do not
-        # disable the diazo theme 'encoder'.
-        # Also see: https://github.com/4teamwork/ftw.testbrowser/commit/8ea19ffbefd251cd6712775336d2a1e76beb79de
-        self.request.response.setHeader('X-Theme-Disabled', 'True')
-        return super(MemberBlockView, self).__call__()
-
     @property
     def image_caption(self):
         mtool = getToolByName(self, "portal_membership")

--- a/ftw/contacts/tests/test_member_block_view.py
+++ b/ftw/contacts/tests/test_member_block_view.py
@@ -27,14 +27,14 @@ class TestMemberBlockView(TestCase):
                          .with_minimal_info(u'Ch\xf6ck', u'4orris')
                          .within(self.contactfolder))
 
-        member_block = create(Builder('member block')
-                              .within(self.contactfolder)
-                              .contact(contact)
-                              .titled(u"A MemberBlock")
-                              .having(show_title=True))
+        create(Builder('member block')
+               .within(self.portal)
+               .contact(contact)
+               .titled(u"A MemberBlock")
+               .having(show_title=True))
 
-        browser.login().visit(member_block, view="block_view")
-        self.assertEqual(u'A MemberBlock', browser.css('h3').first.text)
+        browser.login().visit(self.portal, view='simplelayout-view')
+        self.assertEqual(u'A MemberBlock', browser.css('.ftw-contacts-memberblock h3').first.text)
 
     @browsing
     def test_block_with_deleted_contact_returns_hint_for_editors(self, browser):
@@ -83,15 +83,15 @@ class TestMemberBlockView(TestCase):
                          .with_maximal_info(u'Ch\xf6ck', u'4orris')
                          .within(self.contactfolder))
 
-        member_block = create(Builder('member block')
-                              .within(self.contactfolder)
-                              .contact(contact))
+        create(Builder('member block')
+               .within(self.portal)
+               .contact(contact))
 
-        browser.login().visit(member_block, view="block_view")
+        browser.login().visit(self.portal, view='simplelayout-view')
 
-        self.assertEqual(0, len(browser.css('#member-no-contact-exist')))
-        self.assertEqual(0, len(browser.css('#member-empty')))
-        self.assertEqual(1, len(browser.css('.memberContactInfo')))
+        self.assertEqual(0, len(browser.css('.ftw-contacts-memberblock #member-no-contact-exist')))
+        self.assertEqual(0, len(browser.css('.ftw-contacts-memberblock #member-empty')))
+        self.assertEqual(1, len(browser.css('.ftw-contacts-memberblock .memberContactInfo')))
 
     @browsing
     def test_block_with_deleted_contact_returns_hint_for_anonymous(self, browser):


### PR DESCRIPTION
We disabled dizo for memberblocks so that it does not throw a ecoding error in tests. But it had the side effect to break the whole content page it was in. To fix this we just rewrite the tests to not get in the situation where we get the encoding error and do not disable diazo.