### PR TITLE
Always return False for getIcon index on contacts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Always return False for getIcon on contacts. [mathias.leimgruber]
 
 
 1.10.3 (2020-10-02)

--- a/ftw/contacts/configure.zcml
+++ b/ftw/contacts/configure.zcml
@@ -73,4 +73,8 @@
     </configure>
     <!-- End ftw.zipexport -->
 
+    <configure zcml:condition="have plone-5">
+        <adapter name="getIcon" factory=".indexers.getIcon" />
+    </configure>
+
 </configure>

--- a/ftw/contacts/indexers.py
+++ b/ftw/contacts/indexers.py
@@ -1,0 +1,8 @@
+from ftw.contacts.interfaces import IContact
+from plone.indexer.decorator import indexer
+
+
+@indexer(IContact)
+def getIcon(obj):
+    # Always return False with Plone 5. We never want a Icon here.
+    return False


### PR DESCRIPTION
This fixes displaying the contact icon - otherwise i tries to render a bad mimetype icon on search pages / livesearch.